### PR TITLE
Added dynamic status icons in print_status

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -181,29 +181,32 @@ toggle_trust() {
 
 # Prints a short string with the current bluetooth status
 # Useful for status bars like polybar, etc.
-print_status() {
+ print_status() {
     if power_on; then
-        printf ''
+        if device_connected $1; then
+            printf ''
+            mapfile -t paired_devices < <(bluetoothctl paired-devices | grep Device | cut -d ' ' -f 2)
+            counter=0
 
-        mapfile -t paired_devices < <(bluetoothctl paired-devices | grep Device | cut -d ' ' -f 2)
-        counter=0
+            for device in "${paired_devices[@]}"; do
+                if device_connected $device; then
+                    device_alias=$(bluetoothctl info $device | grep "Alias" | cut -d ' ' -f 2-)
 
-        for device in "${paired_devices[@]}"; do
-            if device_connected $device; then
-                device_alias=$(bluetoothctl info $device | grep "Alias" | cut -d ' ' -f 2-)
+                    if [ $counter -gt 0 ]; then
+                        printf ", %s" "$device_alias"
+                    else
+                        printf " %s" "$device_alias"
+                    fi
 
-                if [ $counter -gt 0 ]; then
-                    printf ", %s" "$device_alias"
-                else
-                    printf " %s" "$device_alias"
+                    ((counter++))
                 fi
-
-                ((counter++))
-            fi
-        done
-        printf "\n"
+            done
+            printf "\n"
+        else
+            echo ""
+        fi
     else
-        echo ""
+        echo "%{F#66ffffff}"
     fi
 }
 


### PR DESCRIPTION
Hello. I made a small modification to the print_status function by adding extra icons to display when bluetooth is off, on, or connected. In this way the user can know visually.
Sorry for the lack of formality or my poor English. This is my first pull request.