### PR TITLE
feat: allow overriding of rofi_command

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -299,7 +299,7 @@ show_menu() {
 }
 
 # Rofi command to pipe into, can add any options here
-rofi_command="rofi -dmenu -no-fixed-num-lines -yoffset -100 -i -p"
+rofi_command=${ROFI_BLUETOOTH_COMMAND:-"rofi -dmenu -no-fixed-num-lines -yoffset -100 -i -p"}
 
 case "$1" in
     --status)


### PR DESCRIPTION
users like me may want to use a very specific rofi command to be called. this simply allows us to provide the command as an env variable "ROFI_BLUETOOTH_COMMAND"

relates to https://github.com/Manjaro-Sway/manjaro-sway/issues/204