### PR TITLE
Added support for bluez / bluetoothctl versions >= 5.65

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -185,7 +185,13 @@ print_status() {
     if power_on; then
         printf ''
 
-        mapfile -t paired_devices < <(bluetoothctl paired-devices | grep Device | cut -d ' ' -f 2)
+        paired_devices_cmd="devices Paired"
+        # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
+        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+            paired_devices_cmd="paired-devices"
+        fi
+
+        mapfile -t paired_devices < <(bluetoothctl $paired_devices_cmd | grep Device | cut -d ' ' -f 2)
         counter=0
 
         for device in "${paired_devices[@]}"; do


### PR DESCRIPTION
In bluetoothctl versions 5.65 and higher the command `bluetoothctl paired-devices` is no longer available. This command is currently used inside the `print_status` function and as a result `rofi-bluetooth --status` doesn't include the currently paired and connected device and only prints the corresponding icon.

In newer versions `bluetoothctl devices Paired` should be used instead. I included a version check to make sure that versions >= 5.65 as well as older versions are supported.