### PR TITLE
Update script for bluetoothctl 5.65+

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -185,7 +185,7 @@ print_status() {
     if power_on; then
         printf ''
 
-        mapfile -t paired_devices < <(bluetoothctl paired-devices | grep Device | cut -d ' ' -f 2)
+        mapfile -t paired_devices < <(bluetoothctl devices Paired | grep Device | cut -d ' ' -f 2)
         counter=0
 
         for device in "${paired_devices[@]}"; do


### PR DESCRIPTION
As of bluetoothctl 5.65+ for paired devices you need to use  `bluetoothctl devices Paired` instead of `bluetoothctl paired-devices`.