### PR TITLE
Removed quote in line 280

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -277,7 +277,7 @@ show_menu() {
     fi
 
     # Open rofi menu, read chosen option
-    chosen="$(echo -e "$options" | "$rofi_command" "Bluetooth")"
+    chosen="$(echo -e "$options" | $rofi_command "Bluetooth")"
 
     # Match chosen option to command
     case "$chosen" in


### PR DESCRIPTION
When running the command rofi-bluetooth it gave the following error.
```
/usr/bin/rofi-bluetooth: line 280: rofi -dmenu -p: command not found
No option chosen.
```

So remove the quotation in line 280 in variable rofi-command seems to make it work