### PR TITLE
Remove quotes around $paired_devices_cmd

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -191,7 +191,7 @@ print_status() {
             paired_devices_cmd="paired-devices"
         fi
 
-        mapfile -t paired_devices < <(bluetoothctl "$paired_devices_cmd" | grep Device | cut -d ' ' -f 2)
+        mapfile -t paired_devices < <(bluetoothctl $paired_devices_cmd | grep Device | cut -d ' ' -f 2)
         counter=0
 
         for device in "${paired_devices[@]}"; do


### PR DESCRIPTION
Hi,

Many thanks for this great tool!

I've noticed that PR https://github.com/nickclyde/rofi-bluetooth/pull/25 has broken `rofi-bluetooth --status` which has stopped showing the connected device names on my end.

I've narrowed it down to the fact that adding double quotes around `$paired_devices_cmd` breaks the `bluetoothctl` command. This is due to the fact that, with double quotes, `bluetoothctl` sees `"devices Paired"` as a single argument when they are in fact two separate arguments. See below example to test it for yourself:
```bash
cmd="devices Paired"
bluetoothctl "$cmd" # <- this line doesn't work
bluetoothctl $cmd   # <- this line works
```

This PR therefore removes the double quotes.