### PR TITLE
Simplify print_status in rofi-bluetooth

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -184,27 +184,13 @@ toggle_trust() {
 print_status() {
     if power_on; then
         printf ''
-
-        paired_devices_cmd="devices Paired"
-        # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
-            paired_devices_cmd="paired-devices"
-        fi
-
-        mapfile -t paired_devices < <(bluetoothctl $paired_devices_cmd | grep Device | cut -d ' ' -f 2)
-        counter=0
-
-        for device in "${paired_devices[@]}"; do
+        sep=""
+        bluetoothctl devices Paired | grep Device | cut -d ' ' -f 2 |
+        while IFS= read -r device; do
             if device_connected "$device"; then
                 device_alias=$(bluetoothctl info "$device" | grep "Alias" | cut -d ' ' -f 2-)
-
-                if [ $counter -gt 0 ]; then
-                    printf ", %s" "$device_alias"
-                else
-                    printf " %s" "$device_alias"
-                fi
-
-                ((counter++))
+                printf "$sep %s" "$device_alias"
+                sep=","
             fi
         done
         printf "\n"
@@ -299,7 +285,7 @@ show_menu() {
         *)
             device=$(bluetoothctl devices | grep "$chosen")
             # Open a submenu if a device is selected
-            if [[ $device ]]; then device_menu "$device"; fi
+            if [ "$device" ]; then device_menu "$device"; fi
             ;;
     esac
 }


### PR DESCRIPTION
This replaces the mapfile + bash array code with a simple pipe into a while loop and simplifies the logic a bit.

It also makes the script more portable. The only remaining bashism is the pair of  echo -e "$options"  calls, which can be replaced with a slightly uglier printf "$options" if posix compatibility is desired. Then the script runs fine on dash.