### PR TITLE
explicitly pass timeout to bluetoothctl to fix scanning

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -57,11 +57,11 @@ scan_on() {
 # Toggles scanning state
 toggle_scan() {
     if scan_on; then
-        kill $(pgrep -f "bluetoothctl scan on")
+        kill $(pgrep -f "bluetoothctl --timeout 5 scan on")
         bluetoothctl scan off
         show_menu
     else
-        bluetoothctl scan on &
+        bluetoothctl --timeout 5 scan on &
         echo "Scanning..."
         sleep 5
         show_menu

--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -61,9 +61,8 @@ toggle_scan() {
         bluetoothctl scan off
         show_menu
     else
-        bluetoothctl --timeout 5 scan on &
+        bluetoothctl --timeout 5 scan on
         echo "Scanning..."
-        sleep 5
         show_menu
     fi
 }


### PR DESCRIPTION
The behavior of `bluetoothctl` seems to have changed, so now you need to manually pass a timeout if you want new devices to be printed to STDOUT and discoverable by rofi-bluetooth. This PR removes `sleep 5` in favor of passing the timeout directly as expected as expected by bluetoothctl. In other words, it unbreaks rofi-bluetooth's scanning feature.