### PR TITLE
Adding bc as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Install from [AUR (rofi-bluetooth-git)](https://aur.archlinux.org/packages/rofi-bluetooth-git/), or:
 
-1. Install dependencies: [rofi](https://github.com/davatorium/rofi) and bluetoothctl (provided by `bluez-utils` in Arch)
+1. Install dependencies: [rofi](https://github.com/davatorium/rofi), bluetoothctl (provided by `bluez-utils` in Arch) and [bc](https://archlinux.org/packages/extra/x86_64/bc/)
 1. `git clone git@github.com:ClydeDroid/rofi-bluetooth.git`
 1. `cd rofi-bluetooth`
 1. `./rofi-bluetooth`
@@ -28,10 +28,29 @@ interval = 1
 click-left = rofi-bluetooth &
 ```
 
+### Waybar configuration
+
+"bluetooth": {
+	// "controller": "controller1", // specify the alias of the controller if there are more than 1 on the system
+	"format": " {status}",
+	"format-disabled": "", // an empty format will hide the module
+	"format-connected": " {num_connections} connected",
+	"tooltip-format": "{controller_alias}\t{controller_address}",
+	"tooltip-format-connected": "{controller_alias}\t{controller_address}\n\n{device_enumerate}",
+	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
+	"on-click": "rofi-bluetooth"
+},
+
 ### i3 keybinding
 
 ```
 bindsym $mod+b exec --no-startup-id rofi-bluetooth
+```
+
+### Hyprland keybinding
+
+```
+bind = $mainMod, B, exec, rofi-bluetooth
 ```
 
 ### Thanks for the inspiration!

--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -14,7 +14,7 @@
 # Thanks to x70b1 (https://github.com/polybar/polybar-scripts/tree/master/polybar-scripts/system-bluetooth-bluetoothctl)
 #
 # Depends on:
-#   Arch repositories: rofi, bluez-utils (contains bluetoothctl)
+#   Arch repositories: rofi, bluez-utils (contains bluetoothctl), bc
 
 # Constants
 divider="---------"


### PR DESCRIPTION
While running the script, I encountered an issue due to the use of the bc command on line 189. The [bc](https://archlinux.org/packages/extra/x86_64/bc/) package is not listed among the script’s dependencies, and it may not be available by default on all systems (my case), which can cause the script to fail. To prevent issues for other users, I listed bc as a dependency. I also included a basic configuration example for using the script with [Waybar](https://github.com/Alexays/Waybar) and [Hyprland](https://github.com/hyprwm/Hyprland). I think that adding this is important because  rofi-bluetooth can also work with [rofi-wayland](https://github.com/lbonn/rofi) (a Wayland-compatible fork of Rofi), but there was no configuration provided for a Wayland environment. I thought it might be helpful to include one for users running Wayland setups.