### PR TITLE
Fix README formatting for Bluetooth module example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ click-left = rofi-bluetooth &
 
 ### Waybar configuration
 
+```
 "bluetooth": {
 	// "controller": "controller1", // specify the alias of the controller if there are more than 1 on the system
 	"format": " {status}",
@@ -40,6 +41,7 @@ click-left = rofi-bluetooth &
 	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
 	"on-click": "rofi-bluetooth"
 },
+```
 
 ### i3 keybinding
 


### PR DESCRIPTION
Wrapped the Bluetooth module configuration block in triple backticks to ensure proper code formatting in the README. This improves readability and prevents confusion when copying the example.

This fixes a formatting issue introduced in the previous commit where the code block was not properly rendered.